### PR TITLE
Corrected documentation for account:balance on a specific account

### DIFF
--- a/docs/onboarding/cli.md
+++ b/docs/onboarding/cli.md
@@ -159,9 +159,9 @@ Gets the current account's balance
 ironfish accounts:balance
 ```
 
-Gets a specific account's public key
+Gets a specific account's balance
 ```sh
-ironfish accounts:balance -a MyNewAccount
+ironfish accounts:balance MyNewAccount
 ```
 
 #### accounts:pay


### PR DESCRIPTION
## Summary
The current docs for account:balance for a specific account seems to be a copy paste error.

## Testing Plan
This is a pretty trivial change.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
